### PR TITLE
Update README to match current project version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Expresso
 
 Tool to analyze, edit and compare text styles in English - [expresso-app.org](http://expresso-app.org).
 
-Expresso first analyses texts using Python [Natural Language Toolkit](http://nltk.org/) package and then computes metrics relevant to writing style.
+Expresso first analyses texts using the [spaCy](https://spacy.io) package and then computes metrics relevant to writing style.


### PR DESCRIPTION
Thank you for your work on this project! Noticed that the `README` still referenced `nltk` while the website references `spaCy`. Hope this helps!